### PR TITLE
[BugFixes] Model class fixes

### DIFF
--- a/lib/src/js_callback_model.dart
+++ b/lib/src/js_callback_model.dart
@@ -62,7 +62,7 @@ class JsTransactionObject {
     data['value'] = value;
     data['from'] = from;
     data['to'] = to;
-    data['data'] = data;
+    data['data'] = this.data;
     return data;
   }
 }
@@ -99,7 +99,7 @@ class JsEthSignTypedData {
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
-    data['data'] = data;
+    data['data'] = this.data;
     data['raw'] = raw;
     return data;
   }


### PR DESCRIPTION
**Issue:**
For `JsAddEthereumChain` and `JsTransactionObject` classes in `js_callback_model.dart`, `data` is the String instance and in the method `toJson()`, the instance of `Map<String, dynamic>` is also defined as `data`. This causes type mismatch and recursion is occurring.